### PR TITLE
Se añade función de carga de cédulas para auxadmin

### DIFF
--- a/app/Http/Controllers/CedulaController.php
+++ b/app/Http/Controllers/CedulaController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Cedula;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Carbon;
+
+class CedulaController extends Controller
+{
+    public function form()
+    {
+        $now = Carbon::now();
+        $mesActual = $now->copy()->startOfMonth()->format('Y-m-01');
+        $anio = $now->year;
+        $bimestre = ceil($now->month / 2);
+        $periodoBimestral = "{$anio}-B{$bimestre}";
+
+        $emaSubida = Cedula::where('mes_ema', $mesActual)->exists();
+        $evaSubida = Cedula::where('periodo_eva', $periodoBimestral)->exists();
+
+        return view('auxadmin.cedulasForm', compact('emaSubida', 'evaSubida'));
+    }
+
+    public function upload(Request $req, $tipo)
+    {
+        $now = now();
+        $anio = $now->year;
+        $mesEma = $now->copy()->startOfMonth()->format('Y-m-01');
+        $bimestre = ceil($now->month / 2);
+        $periodoEva = "{$anio}-B{$bimestre}";
+
+        // Validación
+        if ($tipo === 'ema') {
+            if (Cedula::where('mes_ema', $mesEma)->exists()) {
+                return back()->with('error', 'Ya has subido archivos EMA este mes.');
+            }
+        }
+
+        // Validación
+        if ($tipo === 'eva') {
+            if (Cedula::where('periodo_eva', $periodoEva)->exists()) {
+                return back()->with('error', 'Ya has subido archivos EVA este bimestre.');
+            }
+        }
+
+
+        $record = new Cedula();
+
+        // Subir archivos EMA
+        if ($tipo === 'ema') {
+            foreach (['spyt', 'psc', 'montana'] as $e) {
+                if ($req->hasFile("ema_{$e}")) {
+                    $file = $req->file("ema_{$e}");
+                    $name = "EMA_{$e}_{$mesEma}.pdf";
+                    $path = "cedulas/ema/{$anio}/{$mesEma}";
+                    $file->storeAs($path, $name, 'public');
+                    $record["ema_{$e}"] = "{$path}/{$name}";
+                }
+            }
+            $record->mes_ema = $mesEma;
+        }
+
+        // Subir archivos EVA
+        if ($tipo === 'eva') {
+            foreach (['spyt', 'psc', 'montana'] as $e) {
+                if ($req->hasFile("eva_{$e}")) {
+                    $file = $req->file("eva_{$e}");
+                    $name = "EVA_{$e}_{$periodoEva}.pdf";
+                    $path = "cedulas/eva/{$anio}/{$periodoEva}";
+                    $file->storeAs($path, $name, 'public');
+                    $record["eva_{$e}"] = "{$path}/{$name}";
+                }
+            }
+            $record->periodo_eva = $periodoEva;
+        }
+
+        $record->save();
+
+        return back()->with('success', 'Cédulas cargadas correctamente.');
+    }
+}

--- a/app/Models/Cedula.php
+++ b/app/Models/Cedula.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+
+class Cedula extends Model
+{
+    protected $fillable = [
+        'ema_spyt','ema_psc','ema_montana',
+        'eva_spyt','eva_psc','eva_montana',
+        'mes_ema','periodo_eva'
+    ];
+}
+

--- a/database/migrations/2025_07_24_001700_create_cedulas_table.php
+++ b/database/migrations/2025_07_24_001700_create_cedulas_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cedulas', function (Blueprint $table) {
+            $table->id();
+            $table->string('ema_spyt')->nullable();
+            $table->string('ema_psc')->nullable();
+            $table->string('ema_montana')->nullable();
+            $table->string('eva_spyt')->nullable();
+            $table->string('eva_psc')->nullable();
+            $table->string('eva_montana')->nullable();
+            $table->date('mes_ema')->nullable();
+            $table->string('periodo_eva')->nullable(); // e.g., "2025-B3"
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cedulas');
+    }
+};

--- a/resources/views/auxadmin/cedulasForm.blade.php
+++ b/resources/views/auxadmin/cedulasForm.blade.php
@@ -1,0 +1,101 @@
+<x-app-layout>
+    <x-navbar />
+
+    <div class="py-8 px-6 max-w-4xl mx-auto">
+        @if (session('success'))
+            <div class="bg-green-100 text-green-900 p-4 rounded">{{ session('success') }}</div>
+        @elseif(session('error'))
+            <div class="bg-red-100 text-red-900 p-4 rounded">{{ session('error') }}</div>
+        @endif
+
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 space-y-8">
+            <h2 class="text-2xl font-bold text-gray-700 dark:text-white">Subir Archivos de Cédulas</h2>
+
+            <!-- EMA (Mensual) -->
+            <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4">EMA (Mensual)</h3>
+
+            @if ($emaSubida)
+                <div class="bg-yellow-100 text-yellow-800 p-4 rounded mb-4">
+                    Ya se han subido los archivos EMA para este mes.
+                </div>
+            @else
+                <form action="{{ route('aux.cedulasupload', 'ema') }}" method="POST" enctype="multipart/form-data"
+                    class="space-y-4">
+                    @csrf
+                    @foreach (['ema_spyt' => 'PDF SPyT', 'ema_psc' => 'PDF PSC', 'ema_montana' => 'PDF Montana'] as $name => $label)
+                        <div x-data="dropFile('{{ $name }}')" x-on:dragover.prevent x-on:drop.prevent="handleDrop($event)"
+                            class="border-2 border-dashed rounded-lg p-4 text-center hover:border-blue-400 transition">
+                            <label
+                                class="block text-gray-700 dark:text-gray-300 font-medium mb-1">{{ $label }}</label>
+                            <input type="file" name="{{ $name }}" x-ref="fileInput" accept="application/pdf"
+                                class="hidden" @change="handleFileInput" required>
+                            <button type="button" @click="$refs.fileInput.click()"
+                                class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">
+                                Seleccionar archivo
+                            </button>
+                            <template x-if="fileName">
+                                <p class="mt-2 text-sm text-green-600">Archivo: <strong x-text="fileName"></strong></p>
+                            </template>
+                        </div>
+                    @endforeach
+                    <div class="flex justify-end space-x-3">
+                        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded">Subir
+                            EMA</button>
+                        <a href="{{ url()->previous() }}"
+                            class="bg-white border border-blue-600 text-blue-600 px-6 py-2 rounded hover:bg-blue-50">Cancelar</a>
+                    </div>
+                </form>
+            @endif
+
+
+            <!-- EVA (Bimestral) -->
+            <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4">EVA (Bimestral)</h3>
+
+@if($evaSubida)
+    <div class="bg-yellow-100 text-yellow-800 p-4 rounded mb-4">
+        Ya se han subido los archivos EVA para este bimestre.
+    </div>
+@else
+    <form action="{{ route('aux.cedulasupload', 'eva') }}" method="POST" enctype="multipart/form-data" class="space-y-4">
+        @csrf
+        @foreach(['eva_spyt' => 'PDF SPyT', 'eva_psc' => 'PDF PSC', 'eva_montana' => 'PDF Montana'] as $name => $label)
+            <div x-data="dropFile('{{ $name }}')" x-on:dragover.prevent x-on:drop.prevent="handleDrop($event)" class="border-2 border-dashed rounded-lg p-4 text-center hover:border-blue-400 transition">
+                <label class="block text-gray-700 dark:text-gray-300 font-medium mb-1">{{ $label }}</label>
+                <input type="file" name="{{ $name }}" x-ref="fileInput" accept="application/pdf" class="hidden" @change="handleFileInput" required>
+                <button type="button" @click="$refs.fileInput.click()" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">
+                    Seleccionar archivo
+                </button>
+                <template x-if="fileName">
+                    <p class="mt-2 text-sm text-green-600">Archivo: <strong x-text="fileName"></strong></p>
+                </template>
+            </div>
+        @endforeach
+        <div class="flex justify-end space-x-3">
+            <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded">Subir EVA</button>
+            <a href="{{ url()->previous() }}" class="bg-white border border-blue-600 text-blue-600 px-6 py-2 rounded hover:bg-blue-50">Cancelar</a>
+        </div>
+    </form>
+@endif
+
+        </div>
+    </div>
+
+    <script>
+        function dropFile(inputName) {
+            return {
+                fileName: null,
+                handleDrop(event) {
+                    const file = event.dataTransfer.files[0];
+                    if (file) {
+                        this.$refs.fileInput.files = event.dataTransfer.files;
+                        this.fileName = file.name;
+                    }
+                },
+                handleFileInput(event) {
+                    const file = event.target.files[0];
+                    this.fileName = file ? file.name : null;
+                }
+            }
+        }
+    </script>
+</x-app-layout>

--- a/resources/views/components/auxadmin-navbar.blade.php
+++ b/resources/views/components/auxadmin-navbar.blade.php
@@ -41,7 +41,7 @@
         ],
         [
             'titulo' => 'Cédulas',
-            'ruta' => '#',
+            'ruta' => route('aux.cedulasForm'),
             'icono' => 'file-text',
             'color' => 'bg-yellow-100 dark:bg-yellow-700',
         ],

--- a/routes/web.php
+++ b/routes/web.php
@@ -187,6 +187,11 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/sipare', [App\Http\Controllers\SipareController::class, 'form'])->name('aux.sipareForm');
     Route::post('/sipare/upload', [App\Http\Controllers\SipareController::class, 'upload'])->name('aux.sipareUpload');
+
+   Route::get('/cedulas', [App\Http\Controllers\CedulaController::class,'form'])->name('aux.cedulasForm');
+   Route::post('/cedulas/upload/{tipo}', [App\Http\Controllers\CedulaController::class,'upload'])->name('aux.cedulasupload');
+
+
     //nuevass rutas
     Route::get('/riesgos-trabajo', [RiesgoTrabajoController::class, 'index'])->name('aux.riesgosTrabajo');
     Route::get('/riesgos-trabajo/generar/{user}', [RiesgoTrabajoController::class, 'create'])->name('aux.generarRiesgoForm');


### PR DESCRIPTION
Se introduce el modelo de cédula, la migración, el controlador y la vista de formulario para permitir la carga de archivos PDF de EMA (mensual) y EVA (bimestral) para SPyT, PSC y Montana. Se actualiza la barra de navegación y las rutas para integrar la nueva sección de cédulas para usuarios auxadmin.