### PR TITLE
Permitir la carga de imágenes para archivos de incapacidad

### DIFF
--- a/app/Http/Controllers/IncapacidadController.php
+++ b/app/Http/Controllers/IncapacidadController.php
@@ -45,9 +45,10 @@ class IncapacidadController extends Controller
             'dias_incapacidad' => 'required|integer|min:1',
             'fecha_inicio' => 'required|date',
             'folio' => 'required|string|max:255|unique:incapacidades,folio',
-            'archivo_pdf' => 'required|file|mimes:pdf|max:2048', // PDF, max 2MB
+            'archivo_pdf' => 'required|file|mimes:pdf,jpg,jpeg,png|max:2048',
         ], [
             'folio.unique' => 'El folio de incapacidad ya existe. Por favor, verifica.',
+             'archivo_pdf.mimes' => 'El archivo debe ser un PDF, JPG, JPEG o PNG.',
         ]);
 
         $rutaArchivo = null;

--- a/resources/views/auxadmin/incapacidadForm.blade.php
+++ b/resources/views/auxadmin/incapacidadForm.blade.php
@@ -94,11 +94,11 @@
 
                     <div>
                         <label for="archivo_pdf" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                            Hoja de Incapacidad (PDF)
+                             Hoja de Incapacidad (PDF, JPG, JPEG, PNG)
                         </label>
-                        <input type="file" name="archivo_pdf" id="archivo_pdf" accept=".pdf"
+                        <input type="file" name="archivo_pdf" id="archivo_pdf" accept=".pdf,.jpg,.jpeg,.png"
                                class="mt-1 block w-full text-gray-700 dark:text-gray-300" required>
-                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Solo archivos PDF, máximo 2MB.</p>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Solo archivos PDF, JPG, JPEG, PNG, máximo 2MB.</p>
                     </div>
 
                     <div class="flex items-center justify-end mt-6">

--- a/resources/views/livewire/historial-incapacidades.blade.php
+++ b/resources/views/livewire/historial-incapacidades.blade.php
@@ -43,7 +43,7 @@
                         Folio
                     </th>
                     <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        PDF
+                        PDF,JPG,JPEG,PNG
                     </th>
                 </tr>
             </thead>
@@ -71,7 +71,7 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm">
                         @if($incapacidad->ruta_archivo_pdf)
                             <a href="{{ Storage::url($incapacidad->ruta_archivo_pdf) }}" target="_blank" class="text-blue-600 hover:underline dark:text-blue-400 dark:hover:text-blue-200">
-                                Ver PDF
+                                Ver Archivo
                             </a>
                         @else
                             N/A


### PR DESCRIPTION
Se amplió la compatibilidad de carga de archivos para aceptar los formatos PDF, JPG, JPEG y PNG para documentos de Incapacidad. Se actualizaron la validación, las etiquetas de formulario y los encabezados de tabla para reflejar los nuevos tipos de archivo compatibles.